### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -30,6 +30,8 @@ jobs:
   MSDO:
     # currently only windows latest is supported
     runs-on: windows-latest
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/ColorFulCraft/CFCHistory/security/code-scanning/5](https://github.com/ColorFulCraft/CFCHistory/security/code-scanning/5)

To fix the problem, an explicit `permissions` block should be added either at the workflow root (affecting all jobs by default) or inside the `MSDO` job block (affecting only that job) in `.github/workflows/defender-for-devops.yml`. The best way to fix, per the CodeQL guidance and security best practices, is to set `permissions: contents: read` at the job level (inside the `MSDO` job), since that job only appears to need read access to repository contents for checkout and scan. This adjustment reduces the risk of accidental write operations and follows the principle of least privilege. No changes to existing workflow steps are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
