### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/visit-stats.yml
+++ b/.github/workflows/visit-stats.yml
@@ -1,4 +1,6 @@
 name: Update Visit Statistics
+permissions:
+  contents: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/ColorFulCraft/CFCHistory/security/code-scanning/12](https://github.com/ColorFulCraft/CFCHistory/security/code-scanning/12)

To address the issue, we should explicitly add a `permissions` block either at the root level of the workflow (to set a default for all jobs) or inside the `update-stats` job (to scope to just this job). Since there's only one job, either approach is valid, but adding it at the root is simpler and clearer. The minimal required permission for committing and pushing to the repository is `contents: write`. Therefore, add the following at the root of the workflow (just below `name:` for clarity):  
```yaml
permissions:
  contents: write
```
This keeps the granted permissions as tight as possible while still allowing the "Commit and push if changed" step to succeed. No imports, definitions, or ancillary changes are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
